### PR TITLE
Pin the observability settings so a deploy stops inheriting the dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siki-moe",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "private": true,
   "type": "module",
   "description": "Personal site of Siqi Yang (YouSiki) — siki.moe",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -33,4 +33,32 @@
    */
   "workers_dev": false,
   "preview_urls": true,
+  /*
+   * Observability is otherwise per-Worker dashboard state, so it is spelled out
+   * here — including the values that already are the defaults — to make every
+   * deploy re-assert the same settings instead of inheriting whatever the
+   * account or a past dashboard click left behind.
+   *
+   * The nested `enabled` flags win over the top-level one, so this is: logs on,
+   * traces off. Both keep `persist: true`, which is what makes a record
+   * queryable in the dashboard rather than merely streamed to `wrangler tail`.
+   *
+   * Assets-only means no script is invoked, so nothing here has anything to
+   * report today; it is a floor for the day this Worker grows a `main`.
+   */
+  "observability": {
+    "enabled": false,
+    "head_sampling_rate": 1,
+    "logs": {
+      "enabled": true,
+      "head_sampling_rate": 1,
+      "persist": true,
+      "invocation_logs": true,
+    },
+    "traces": {
+      "enabled": false,
+      "persist": true,
+      "head_sampling_rate": 1,
+    },
+  },
 }


### PR DESCRIPTION
Observability is per-Worker dashboard state otherwise, so every value is spelled out in `wrangler.jsonc` — the defaults included — and each deploy re-asserts the same thing rather than whatever the account or a past click left behind.

Two things worth knowing about the block:

- The nested `enabled` flags win over the top-level one, so the effect is **logs on, traces off**, despite `"enabled": false` at the top. Both sub-objects keep `persist: true`, which is what makes a record queryable in the dashboard rather than merely streamed to `wrangler tail`.
- Assets-only means no script is invoked, so none of this has anything to report today. It is a floor for the day this Worker grows a `main`.

Only the top-level `enabled` and `head_sampling_rate` are in Cloudflare's docs; `logs.enabled`, `persist` and the whole `traces` object exist only in wrangler's `config-schema.json`, which is the authority for this block.

## Verification

- `wrangler types` (runs the full config validation) — clean, no unexpected-field diagnostics
- `wrangler deploy --dry-run` against a stub `dist/` — passes
- `prettier --check wrangler.jsonc` — passes
- Every key checked field-by-field against `node_modules/wrangler/config-schema.json` at wrangler 4.121.0

Not confirmed: whether `observability` is a version-level or Worker-level setting, i.e. whether `versions upload` writes it or only `deploy` does. Cloudflare publishes no list of the two, so the release is the place that will actually show it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)